### PR TITLE
feat(stylelint-config): use `stylelint-plugin-logical-css`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20490,6 +20490,19 @@
                 "stylelint": "^14.0.0 || ^15.0.0 || ^16.0.1"
             }
         },
+        "node_modules/stylelint-plugin-logical-css": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/stylelint-plugin-logical-css/-/stylelint-plugin-logical-css-1.2.3.tgz",
+            "integrity": "sha512-yzSDrw4yyZJosgMablqqQzCeJmsPRAK/H7X1XzliQkYvoC/ZHBfHKos27dQEwwSLBUaYg+7nJ1ct7OlST4iqZA==",
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=18.12.0"
+            },
+            "peerDependencies": {
+                "stylelint": "^14.0.0 || ^15.0.0 || ^16.0.0"
+            }
+        },
         "node_modules/stylelint-prettier": {
             "version": "5.0.3",
             "resolved": "https://registry.npmjs.org/stylelint-prettier/-/stylelint-prettier-5.0.3.tgz",
@@ -22598,6 +22611,7 @@
                 "stylelint": "^16.21.1",
                 "stylelint-config-standard": "^37.0.0",
                 "stylelint-order": "^6.0.4",
+                "stylelint-plugin-logical-css": "1.2.3",
                 "stylelint-rem-over-px": "^1.0.2",
                 "stylelint-use-logical": "^2.1.2"
             }

--- a/projects/stylelint-config/index.js
+++ b/projects/stylelint-config/index.js
@@ -3,6 +3,7 @@ module.exports = {
         'stylelint-order',
         'stylelint-rem-over-px',
         'stylelint-use-logical',
+        'stylelint-plugin-logical-css',
         '@stylistic/stylelint-plugin',
     ],
     extends: ['@stylistic/stylelint-config'],
@@ -172,22 +173,55 @@ module.exports = {
                 unspecified: 'bottom',
             },
         ],
+        'plugin/use-logical-properties-and-values': [
+            true,
+            {
+                ignore: [
+                    'border-top', // Safari 14.5+
+                    'border-bottom', // Safari 14.5+
+                    'border-top-color', // Safari 14.5+
+                    'border-bottom-color', // Safari 14.5+
+                    'border-top-style', // Safari 14.5+
+                    'border-bottom-style', // Safari 14.5+
+                    'border-top-width', // Safari 14.5+
+                    'border-bottom-width', // Safari 14.5+
+                    'border-left', // Safari 14.5+
+                    'border-right', // Safari 14.5+
+                    'border-left-color', // Safari 14.5+
+                    'border-right-color', // Safari 14.5+
+                    'border-left-style', // Safari 14.5+
+                    'border-right-style', // Safari 14.5+
+                    'border-left-width', // Safari 14.5+
+                    'border-right-width', // Safari 14.5+
+                    'top', // Safari 14.5+
+                    'bottom', // Safari 14.5+
+                    'left', // Safari 14.5+
+                    'right', // Safari 14.5+
+                    'scroll-margin-bottom', // Safari 15+
+                    'scroll-margin-top', // Safari 15+
+                    'scroll-margin-left', // Safari 15+
+                    'scroll-margin-right', // Safari 15+
+                    'scroll-padding-bottom', // Safari 15+
+                    'scroll-padding-top', // Safari 15+
+                    'scroll-padding-left', // Safari 15+
+                    'scroll-padding-right', // Safari 15+
+                    'border-bottom-left-radius', // Safari 15+ & Chrome 89+
+                    'border-bottom-right-radius', // Safari 15+ & Chrome 89+
+                    'border-top-left-radius', // Safari 15+ & Chrome 89+
+                    'border-top-right-radius', // Safari 15+ & Chrome 89+
+                    'clear', //  Safari 15+ & Chrome 118+
+                    'float', //  Safari 15+ & Chrome 118+
+                    'overscroll-behavior-x', // Safari 16+
+                    'overscroll-behavior-y', // Safari 16+
+                    'contain-intrinsic-height', //  Safari 17+ & Chrome 95+
+                    'contain-intrinsic-width', //  Safari 17+ & Chrome 95+
+                    'overflow-y', // Safari 26+ & Chrome 135+
+                    'overflow-x', // Safari 26+ & Chrome 135+
+                    'resize', // Chrome 118+ & Safari NaN+
+                ],
+            },
+        ],
         'property-disallowed-list': [
-            'margin-left', // use margin-inline-start
-            'margin-right', // use margin-inline-end
-            'margin-top', // use margin-block-start
-            'margin-bottom', // use margin-block-end
-            'padding-left', // use padding-inline-start
-            'padding-right', // use padding-inline-end
-            'padding-top', // use padding-block-start
-            'padding-bottom', // use padding-block-end
-            'border-left', // use border-inline-start
-            'border-right', // use border-inline-end
-            'border-top', // use border-block-start
-            'border-bottom', // use border-block-end
-            'border-inline', // shorthand works in Safari 14+
-            'padding-inline', // shorthand works in Safari 14+
-            'margin-inline', // shorthand works in Safari 14+
             '/^word-wrap$/', // The word-wrap property was renamed to overflow-wrap in CSS3
         ],
         'property-no-unknown': [

--- a/projects/stylelint-config/index.js
+++ b/projects/stylelint-config/index.js
@@ -222,6 +222,9 @@ module.exports = {
             },
         ],
         'property-disallowed-list': [
+            'border-inline', // shorthand works in Safari 14.5+
+            'padding-inline', // shorthand works in Safari 14.5+
+            'margin-inline', // shorthand works in Safari 14.5+
             '/^word-wrap$/', // The word-wrap property was renamed to overflow-wrap in CSS3
         ],
         'property-no-unknown': [

--- a/projects/stylelint-config/package.json
+++ b/projects/stylelint-config/package.json
@@ -21,7 +21,8 @@
         "stylelint-config-standard": "^37.0.0",
         "stylelint-order": "^6.0.4",
         "stylelint-rem-over-px": "^1.0.2",
-        "stylelint-use-logical": "^2.1.2"
+        "stylelint-use-logical": "^2.1.2",
+        "stylelint-plugin-logical-css": "1.2.3"
     },
     "publishConfig": {
         "access": "public"

--- a/projects/stylelint-config/package.json
+++ b/projects/stylelint-config/package.json
@@ -20,9 +20,9 @@
         "stylelint": "^16.21.1",
         "stylelint-config-standard": "^37.0.0",
         "stylelint-order": "^6.0.4",
+        "stylelint-plugin-logical-css": "1.2.3",
         "stylelint-rem-over-px": "^1.0.2",
-        "stylelint-use-logical": "^2.1.2",
-        "stylelint-plugin-logical-css": "1.2.3"
+        "stylelint-use-logical": "^2.1.2"
     },
     "publishConfig": {
         "access": "public"


### PR DESCRIPTION
https://stylelint.io/awesome-stylelint/#internationalization

```css
.test {
    margin-top: 1rem;
}
```

### Previous behavior

```
> npm run stylelint


projects/project-name/debug.css
  2:5  ✖  Unexpected property "margin-top"  property-disallowed-list

✖ 1 problem (1 error, 0 warnings)
```

### New behavior
```
> npm run stylelint

projects/project-name/debug.css
  2:5  ✖  Unexpected "margin-top" property. Use "margin-block-start".  plugin/use-logical-properties-and-values

✖ 1 problem (1 error, 0 warnings)
```

```
> npm run stylelint -- --fix

# Exit 0  
# margin-top is automatically replaced by margin-block-start
```