### PR TITLE
feat(eslint-plugin-experience-next): allow function names starting with `provide` prefix

### DIFF
--- a/projects/eslint-plugin-experience-next/rules/convention.ts
+++ b/projects/eslint-plugin-experience-next/rules/convention.ts
@@ -29,7 +29,7 @@ export const TUI_CUSTOM_TAIGA_NAMING_CONVENTION = [
     {
         format: ['PascalCase'],
         modifiers: ['exported'],
-        prefix: ['tui'],
+        prefix: ['tui', 'provide'],
         selector: 'function',
     },
 ] as const;


### PR DESCRIPTION


Fixes https://github.com/taiga-family/toolkit/issues/1286
