### PR TITLE
feat(stylelint-config): allow dvh unit

### DIFF
--- a/projects/stylelint-config/configs/recommended.ts
+++ b/projects/stylelint-config/configs/recommended.ts
@@ -311,7 +311,7 @@ const config: StylelintConfig = {
                     'focus-visible', // Safari 15+
                     'fullscreen', // Safari 16+
                 ],
-                ignoreUnits: ['svh'],
+                ignoreUnits: ['svh', 'dvh'],
             },
         ],
         'property-disallowed-list': [
@@ -393,6 +393,7 @@ const config: StylelintConfig = {
             'vw',
             'fr',
             'svh',
+            'dvh',
             'lh',
         ],
         'unit-no-unknown': true,

--- a/projects/stylelint-config/tests/valid.css
+++ b/projects/stylelint-config/tests/valid.css
@@ -79,3 +79,7 @@ caption {
     text-decoration: none dashed currentColor 1px;
     text-decoration-color: color-mix(in lch, currentColor, transparent);
 }
+
+.viewport {
+    block-size: 100dvh;
+}


### PR DESCRIPTION
## Motivation

Allow `dvh` for layouts that need to react to the dynamic viewport height on mobile browsers without local `stylelint-disable` comments.

## Changes

- add `dvh` to `unit-allowed-list`
- ignore `dvh` in `plugin/use-baseline`, matching the existing `svh` handling
- add a valid CSS fixture with `block-size: 100dvh`