### PR TITLE
feat(stylelint-config): support Angular inline styles

### DIFF
--- a/projects/stylelint-config/README.md
+++ b/projects/stylelint-config/README.md
@@ -1,6 +1,6 @@
 # @taiga-ui/stylelint-config
 
-Common Stylelint configuration for Taiga UI projects.
+Common Stylelint configuration for Taiga UI projects, including Angular inline styles in TypeScript files.
 
 ```bash
 npm i -D stylelint @taiga-ui/stylelint-config
@@ -24,6 +24,46 @@ export default {
   extends: ['@taiga-ui/stylelint-config', '@taiga-ui/stylelint-config/taiga-specific'],
 };
 ```
+
+## Angular inline styles in TypeScript
+
+The recommended config automatically checks CSS and Less in the `styles` metadata of Angular `@Component` decorators
+in `.ts` files. Add `ts` to your Stylelint file glob:
+
+```bash
+stylelint '**/*.{less,css,ts}'
+```
+
+To apply autofixes:
+
+```bash
+stylelint '**/*.{less,css,ts}' --fix
+```
+
+Both a single string and an array of strings are supported, including template literals:
+
+```ts
+import {Component} from '@angular/core';
+
+@Component({
+  template: '',
+  styles: `
+    :host {
+      color: #ffffff;
+    }
+  `,
+})
+export class ExampleComponent {}
+```
+
+For example, `--fix` changes `#ffffff` to `#fff` while preserving the surrounding TypeScript. Diagnostics point to the
+original TypeScript locations. Each style block is checked independently, so matching imports in different components
+are not reported as duplicates.
+
+TypeScript expressions are not evaluated. References such as `styles: externalStyles` and function calls are skipped.
+Template expressions inside quoted CSS values, such as `[data-tui-version='${TUI_VERSION}']`, are supported when the
+block can be parsed as Less; unparseable dynamic blocks are skipped. Files without extractable component styles are
+left unchanged. This checks component styles, not TypeScript code or inline HTML templates.
 
 ## Configs
 

--- a/projects/stylelint-config/README.md
+++ b/projects/stylelint-config/README.md
@@ -27,8 +27,8 @@ export default {
 
 ## Angular inline styles in TypeScript
 
-The recommended config automatically checks CSS and Less in the `styles` metadata of Angular `@Component` decorators
-in `.ts` files. Add `ts` to your Stylelint file glob:
+The recommended config automatically checks CSS and Less in the `styles` metadata of Angular `@Component` decorators in
+`.ts` files. Add `ts` to your Stylelint file glob:
 
 ```bash
 stylelint '**/*.{less,css,ts}'
@@ -62,8 +62,8 @@ are not reported as duplicates.
 
 TypeScript expressions are not evaluated. References such as `styles: externalStyles` and function calls are skipped.
 Template expressions inside quoted CSS values, such as `[data-tui-version='${TUI_VERSION}']`, are supported when the
-block can be parsed as Less; unparseable dynamic blocks are skipped. Files without extractable component styles are
-left unchanged. This checks component styles, not TypeScript code or inline HTML templates.
+block can be parsed as Less; unparseable dynamic blocks are skipped. Files without extractable component styles are left
+unchanged. This checks component styles, not TypeScript code or inline HTML templates.
 
 ## Configs
 

--- a/projects/stylelint-config/angular.ts
+++ b/projects/stylelint-config/angular.ts
@@ -1,0 +1,15 @@
+import {type Config} from 'stylelint';
+
+import angularInlineStyles from './syntaxes/angular-inline-styles';
+
+const config: Config = {
+    overrides: [
+        {
+            files: ['*.ts', '**/*.ts'],
+            customSyntax: angularInlineStyles as unknown as Config['customSyntax'],
+            rules: {'no-empty-source': null},
+        },
+    ],
+};
+
+export default config;

--- a/projects/stylelint-config/index.ts
+++ b/projects/stylelint-config/index.ts
@@ -1,1 +1,11 @@
-export {default} from './configs/recommended';
+import {type Config} from 'stylelint';
+
+import angular from './angular';
+import recommended from './configs/recommended';
+
+const config: Config = {
+    ...recommended,
+    overrides: [...(recommended.overrides ?? []), ...(angular.overrides ?? [])],
+};
+
+export default config;

--- a/projects/stylelint-config/syntaxes/angular-inline-styles/extract-component-styles.ts
+++ b/projects/stylelint-config/syntaxes/angular-inline-styles/extract-component-styles.ts
@@ -1,0 +1,134 @@
+import {createRequire} from 'node:module';
+
+import type ts from 'typescript';
+
+export interface StyleRange {
+    readonly dynamic: boolean;
+    readonly end: number;
+    readonly start: number;
+}
+
+const requireModule = createRequire(`${process.cwd()}/package.json`);
+let typescript: typeof ts | undefined;
+
+function getTypescript(): typeof ts {
+    typescript ??= requireModule('typescript') as typeof ts;
+
+    return typescript;
+}
+
+function getPropertyName(name: ts.PropertyName): string | null {
+    const compiler = getTypescript();
+    const supported =
+        compiler.isIdentifier(name) ||
+        compiler.isStringLiteral(name) ||
+        compiler.isNoSubstitutionTemplateLiteral(name);
+
+    return supported ? name.text : null;
+}
+
+function getComponentMetadata(
+    expression: ts.Expression,
+): ts.ObjectLiteralExpression | null {
+    const compiler = getTypescript();
+
+    if (!compiler.isCallExpression(expression)) {
+        return null;
+    }
+
+    const callee = expression.expression;
+    let name: string | null = null;
+
+    if (compiler.isIdentifier(callee)) {
+        name = callee.text;
+    } else if (compiler.isPropertyAccessExpression(callee)) {
+        name = callee.name.text;
+    }
+
+    if (name !== 'Component') {
+        return null;
+    }
+
+    const [metadata] = expression.arguments;
+
+    return metadata && compiler.isObjectLiteralExpression(metadata) ? metadata : null;
+}
+
+function getLiteralRange(
+    node: ts.Expression,
+    sourceFile: ts.SourceFile,
+): StyleRange | null {
+    const compiler = getTypescript();
+    const isStatic =
+        compiler.isStringLiteral(node) || compiler.isNoSubstitutionTemplateLiteral(node);
+
+    const isDynamic = compiler.isTemplateExpression(node);
+
+    return isStatic || isDynamic
+        ? {
+              dynamic: isDynamic,
+              end: node.getEnd() - 1,
+              start: node.getStart(sourceFile) + 1,
+          }
+        : null;
+}
+
+function getStyleRanges(
+    initializer: ts.Expression,
+    sourceFile: ts.SourceFile,
+): StyleRange[] {
+    const compiler = getTypescript();
+    const direct = getLiteralRange(initializer, sourceFile);
+
+    if (direct) {
+        return [direct];
+    }
+
+    return compiler.isArrayLiteralExpression(initializer)
+        ? initializer.elements.flatMap((element) => {
+              const range = getLiteralRange(element, sourceFile);
+
+              return range ? [range] : [];
+          })
+        : [];
+}
+
+export function extractComponentStyles(source: string, filename: string): StyleRange[] {
+    const compiler = getTypescript();
+    const sourceFile = compiler.createSourceFile(
+        filename,
+        source,
+        compiler.ScriptTarget.Latest,
+        true,
+        compiler.ScriptKind.TS,
+    );
+
+    const ranges: StyleRange[] = [];
+
+    function visit(node: ts.Node): void {
+        if (compiler.isClassDeclaration(node) && compiler.canHaveDecorators(node)) {
+            for (const decorator of compiler.getDecorators(node) ?? []) {
+                const metadata = getComponentMetadata(decorator.expression);
+
+                if (!metadata) {
+                    continue;
+                }
+
+                for (const property of metadata.properties) {
+                    if (
+                        compiler.isPropertyAssignment(property) &&
+                        getPropertyName(property.name) === 'styles'
+                    ) {
+                        ranges.push(...getStyleRanges(property.initializer, sourceFile));
+                    }
+                }
+            }
+        }
+
+        compiler.forEachChild(node, visit);
+    }
+
+    visit(sourceFile);
+
+    return ranges;
+}

--- a/projects/stylelint-config/syntaxes/angular-inline-styles/index.ts
+++ b/projects/stylelint-config/syntaxes/angular-inline-styles/index.ts
@@ -1,0 +1,117 @@
+import {type Node, type ProcessOptions, type Root, root} from 'postcss';
+import less from 'postcss-less';
+
+import {extractComponentStyles} from './extract-component-styles';
+import {getRaws, remapNodeSource} from './remap-source';
+
+type Builder = (output: string, node?: Node, type?: string) => void;
+
+type Stringifiable = string | {toString(): string};
+
+function parseStyle(
+    snippet: string,
+    opts: ProcessOptions,
+    dynamic: boolean,
+): Root | null {
+    try {
+        return less.parse(snippet, opts);
+    } catch (error) {
+        if (dynamic) {
+            return null;
+        }
+
+        throw error;
+    }
+}
+
+function parse(sourceInput: Stringifiable, opts: ProcessOptions = {}): Root {
+    const source = String(sourceInput);
+    const output = root();
+    let lastNode: Node | null = null;
+    let previousRangeEnd = 0;
+
+    getRaws(output).angularSource = source;
+
+    for (const range of extractComponentStyles(source, opts.from ?? 'component.ts')) {
+        const snippet = source.slice(range.start, range.end);
+        const parsed = parseStyle(snippet, opts, range.dynamic);
+
+        if (!parsed) {
+            continue;
+        }
+
+        const nodes = [...parsed.nodes];
+
+        if (nodes.length === 0) {
+            continue;
+        }
+
+        let previousLocalEnd = 0;
+
+        nodes.forEach((node, index) => {
+            const localStart = node.source?.start?.offset ?? 0;
+            const localEnd = node.source?.end?.offset ?? localStart;
+            const raws = getRaws(node);
+            const angularPrefix =
+                index === 0 ? source.slice(previousRangeEnd, range.start) : '';
+
+            const localPrefix = snippet.slice(previousLocalEnd, localStart);
+
+            raws.angularCodeBefore = `${angularPrefix}${localPrefix}`;
+
+            if (index === nodes.length - 1) {
+                raws.angularCodeAfter = snippet.slice(localEnd);
+            }
+
+            previousLocalEnd = localEnd;
+        });
+
+        parsed.walk((node) => remapNodeSource(node, source, range.start));
+        output.append(nodes);
+        previousRangeEnd = range.end;
+        lastNode = nodes[nodes.length - 1] ?? null;
+    }
+
+    if (lastNode) {
+        const raws = getRaws(lastNode);
+        const angularSuffix = source.slice(previousRangeEnd);
+
+        raws.angularCodeAfter = `${raws.angularCodeAfter ?? ''}${angularSuffix}`;
+    }
+
+    return output;
+}
+
+function stringify(node: Node, builder: Builder): void {
+    const raws = getRaws(node);
+
+    if (node.type !== 'root' || raws.angularSource === undefined) {
+        less.stringify(node, builder);
+
+        return;
+    }
+
+    const angularRoot = node as Root;
+
+    if (angularRoot.nodes.length === 0) {
+        builder(raws.angularSource, node);
+
+        return;
+    }
+
+    for (const child of angularRoot.nodes) {
+        const childRaws = getRaws(child);
+
+        if (childRaws.angularCodeBefore) {
+            builder(childRaws.angularCodeBefore, child, 'raw');
+        }
+
+        less.stringify(child, builder);
+
+        if (childRaws.angularCodeAfter) {
+            builder(childRaws.angularCodeAfter, child, 'raw');
+        }
+    }
+}
+
+export default {parse, stringify};

--- a/projects/stylelint-config/syntaxes/angular-inline-styles/index.ts
+++ b/projects/stylelint-config/syntaxes/angular-inline-styles/index.ts
@@ -1,4 +1,4 @@
-import {type Node, type ProcessOptions, type Root, root} from 'postcss';
+import {Input, type Node, type ProcessOptions, type Root, root} from 'postcss';
 import less from 'postcss-less';
 
 import {extractComponentStyles} from './extract-component-styles';
@@ -26,7 +26,13 @@ function parseStyle(
 
 function parse(sourceInput: Stringifiable, opts: ProcessOptions = {}): Root {
     const source = String(sourceInput);
-    const output = root();
+    const inlineSource = {
+        inline: true,
+        input: new Input(source, opts),
+        start: {column: 1, line: 1, offset: 0},
+    };
+
+    const output = root({source: inlineSource});
     let lastNode: Node | null = null;
     let previousRangeEnd = 0;
 

--- a/projects/stylelint-config/syntaxes/angular-inline-styles/index.ts
+++ b/projects/stylelint-config/syntaxes/angular-inline-styles/index.ts
@@ -1,4 +1,12 @@
-import {Input, type Node, type ProcessOptions, type Root, root} from 'postcss';
+import {
+    type AnyNode,
+    type Document,
+    document,
+    Input,
+    type Node,
+    type ProcessOptions,
+    type Root,
+} from 'postcss';
 import less from 'postcss-less';
 
 import {extractComponentStyles} from './extract-component-styles';
@@ -24,7 +32,7 @@ function parseStyle(
     }
 }
 
-function parse(sourceInput: Stringifiable, opts: ProcessOptions = {}): Root {
+function parse(sourceInput: Stringifiable, opts: ProcessOptions = {}): Document {
     const source = String(sourceInput);
     const inlineSource = {
         inline: true,
@@ -32,7 +40,7 @@ function parse(sourceInput: Stringifiable, opts: ProcessOptions = {}): Root {
         start: {column: 1, line: 1, offset: 0},
     };
 
-    const output = root({source: inlineSource});
+    const output = document({source: inlineSource});
     let lastNode: Node | null = null;
     let previousRangeEnd = 0;
 
@@ -73,7 +81,9 @@ function parse(sourceInput: Stringifiable, opts: ProcessOptions = {}): Root {
         });
 
         parsed.walk((node) => remapNodeSource(node, source, range.start));
-        output.append(nodes);
+        remapNodeSource(parsed, source, range.start);
+        parsed.source = {...inlineSource, ...parsed.source};
+        output.append(parsed);
         previousRangeEnd = range.end;
         lastNode = nodes[nodes.length - 1] ?? null;
     }
@@ -88,24 +98,22 @@ function parse(sourceInput: Stringifiable, opts: ProcessOptions = {}): Root {
     return output;
 }
 
-function stringify(node: Node, builder: Builder): void {
+function stringify(node: AnyNode, builder: Builder): void {
     const raws = getRaws(node);
 
-    if (node.type !== 'root' || raws.angularSource === undefined) {
+    if (node.type !== 'document' || raws.angularSource === undefined) {
         less.stringify(node, builder);
 
         return;
     }
 
-    const angularRoot = node as Root;
-
-    if (angularRoot.nodes.length === 0) {
+    if (node.nodes.length === 0) {
         builder(raws.angularSource, node);
 
         return;
     }
 
-    for (const child of angularRoot.nodes) {
+    for (const child of node.nodes.flatMap((styleRoot) => styleRoot.nodes)) {
         const childRaws = getRaws(child);
 
         if (childRaws.angularCodeBefore) {

--- a/projects/stylelint-config/syntaxes/angular-inline-styles/remap-source.ts
+++ b/projects/stylelint-config/syntaxes/angular-inline-styles/remap-source.ts
@@ -1,0 +1,70 @@
+import {type Node} from 'postcss';
+
+interface Position {
+    column: number;
+    line: number;
+    offset?: number;
+}
+
+interface MutableSource {
+    readonly input: {
+        css: string;
+    };
+    end?: Position;
+    start?: Position;
+}
+
+export interface AngularRaws {
+    angularCodeAfter?: string;
+    angularCodeBefore?: string;
+    angularSource?: string;
+}
+
+export function getRaws(node: Node): AngularRaws {
+    return node.raws;
+}
+
+function getPosition(source: string, offset: number): Position {
+    const prefix = source.slice(0, offset);
+    const lastLineBreak = prefix.lastIndexOf('\n');
+    const line = prefix.split('\n').length;
+
+    return {
+        column: offset - lastLineBreak,
+        line,
+        offset,
+    };
+}
+
+function remapPosition(position: Position, base: Position, offset: number): void {
+    const localLine = position.line;
+
+    position.line += base.line - 1;
+
+    if (localLine === 1) {
+        position.column += base.column - 1;
+    }
+
+    if (typeof position.offset === 'number') {
+        position.offset += offset;
+    }
+}
+
+export function remapNodeSource(node: Node, source: string, rangeStart: number): void {
+    if (!node.source) {
+        return;
+    }
+
+    const nodeSource = node.source as unknown as MutableSource;
+    const base = getPosition(source, rangeStart);
+
+    nodeSource.input.css = source;
+
+    if (nodeSource.start) {
+        remapPosition(nodeSource.start, base, rangeStart);
+    }
+
+    if (nodeSource.end) {
+        remapPosition(nodeSource.end, base, rangeStart);
+    }
+}

--- a/projects/stylelint-config/syntaxes/postcss-less.d.ts
+++ b/projects/stylelint-config/syntaxes/postcss-less.d.ts
@@ -1,0 +1,13 @@
+declare module 'postcss-less' {
+    import {type Node, type ProcessOptions, type Root} from 'postcss';
+
+    type Builder = (output: string, node?: Node, type?: string) => void;
+    type Stringifiable = string | {toString(): string};
+
+    const syntax: {
+        parse(source: Stringifiable, opts?: ProcessOptions): Root;
+        stringify(node: Node, builder: Builder): void;
+    };
+
+    export default syntax;
+}

--- a/projects/stylelint-config/tests/angular-inline-styles.spec.ts
+++ b/projects/stylelint-config/tests/angular-inline-styles.spec.ts
@@ -1,0 +1,359 @@
+import {describe, expect, it} from '@jest/globals';
+
+import angularConfig from '../angular';
+import {type LintOutput, lintWithStylelint} from './stylelint-test-utils';
+
+function dedent([source]: TemplateStringsArray): string {
+    const indentation = source.match(/^[ \t]*(?=\S)/m)?.[0] ?? '';
+
+    return source.trim().replaceAll(`\n${indentation}`, '\n');
+}
+
+async function lint(
+    code: string,
+    rules: Readonly<Record<string, unknown>>,
+    fix = false,
+): Promise<LintOutput> {
+    return lintWithStylelint({
+        code,
+        codeFilename: 'test.component.ts',
+        config: {
+            ...angularConfig,
+            rules,
+        },
+        fix,
+    });
+}
+
+describe('Angular inline styles', () => {
+    it('reports Stylelint warnings at the original TypeScript location', async () => {
+        const code = dedent`
+            import {Component} from '@angular/core';
+
+            @Component({
+                styles: \`
+                    :host {
+                        unknown-property: 1;
+                    }
+                \`,
+            })
+            export class Test {}
+        `;
+
+        const result = await lint(code, {'property-no-unknown': true});
+
+        expect(result.warnings).toEqual([
+            expect.objectContaining({
+                column: 13,
+                line: 6,
+                rule: 'property-no-unknown',
+            }),
+        ]);
+    });
+
+    it('lints a single-quoted style', async () => {
+        const code = dedent`
+            @Component({
+                styles: '.test { unknown-property: 1; }',
+            })
+            export class Test {}
+        `;
+
+        const result = await lint(code, {'property-no-unknown': true});
+
+        expect(result.warnings).toEqual([
+            expect.objectContaining({
+                line: 2,
+                rule: 'property-no-unknown',
+                text: expect.stringContaining('unknown-property'),
+            }),
+        ]);
+    });
+
+    it('lints every static style in an array', async () => {
+        const code = dedent`
+            @Component({
+                styles: [
+                    \`.first { unknown-first: 1; }\`,
+                    '.second { unknown-second: 2; }',
+                ],
+            })
+            export class Test {}
+        `;
+
+        const result = await lint(code, {'property-no-unknown': true});
+
+        expect(result.warnings).toHaveLength(2);
+        expect(result.warnings.map(({text}) => text)).toEqual([
+            expect.stringContaining('unknown-first'),
+            expect.stringContaining('unknown-second'),
+        ]);
+    });
+
+    it('lints literals and ignores unsupported expressions in arrays', async () => {
+        const code = dedent`
+            @Component({
+                styles: [
+                    externalStyles,
+                    \`.first { unknown-first: 1; }\`,
+                    getStyles(),
+                    '.second { unknown-second: 2; }',
+                ],
+            })
+            export class Test {}
+        `;
+
+        const result = await lint(code, {'property-no-unknown': true});
+
+        expect(result.warnings.map(({text}) => text)).toEqual([
+            expect.stringContaining('unknown-first'),
+            expect.stringContaining('unknown-second'),
+        ]);
+    });
+
+    it('supports quoted styles property names', async () => {
+        const code = dedent`
+            @Component({
+                'styles': \`.test { unknown-property: 1; }\`,
+            })
+            export class Test {}
+        `;
+
+        const result = await lint(code, {'property-no-unknown': true});
+
+        expect(result.warnings).toEqual([
+            expect.objectContaining({
+                line: 2,
+                rule: 'property-no-unknown',
+                text: expect.stringContaining('unknown-property'),
+            }),
+        ]);
+    });
+
+    it('supports namespace-qualified Component decorators', async () => {
+        const code = dedent`
+            import * as ng from '@angular/core';
+
+            @ng.Component({
+                styles: \`.test { unknown-property: 1; }\`,
+            })
+            export class Test {}
+        `;
+
+        const result = await lint(code, {'property-no-unknown': true});
+
+        expect(result.warnings).toEqual([
+            expect.objectContaining({
+                line: 4,
+                rule: 'property-no-unknown',
+                text: expect.stringContaining('unknown-property'),
+            }),
+        ]);
+    });
+
+    it('ignores styles metadata of decorators other than Component', async () => {
+        const code = dedent`
+            @Directive({
+                styles: \`.fake { unknown-property: 1; }\`,
+            })
+            export class Test {}
+        `;
+
+        const result = await lint(code, {'property-no-unknown': true});
+
+        expect(result.warnings).toEqual([]);
+    });
+
+    it('lints styles from multiple components in the same file', async () => {
+        const code = dedent`
+            @Component({
+                styles: \`.first { unknown-first: 1; }\`,
+            })
+            export class First {}
+
+            @Component({
+                styles: \`.second { unknown-second: 2; }\`,
+            })
+            export class Second {}
+        `;
+
+        const result = await lint(code, {'property-no-unknown': true});
+
+        expect(result.warnings).toEqual([
+            expect.objectContaining({
+                line: 2,
+                text: expect.stringContaining('unknown-first'),
+            }),
+            expect.objectContaining({
+                line: 7,
+                text: expect.stringContaining('unknown-second'),
+            }),
+        ]);
+    });
+
+    it('supports Less in inline styles', async () => {
+        const code = dedent`
+            @Component({
+                styles: \`
+                    @color: red;
+
+                    :host {
+                        color: @color;
+                    }
+                \`,
+            })
+            export class Test {}
+        `;
+
+        const result = await lint(code, {'property-no-unknown': true});
+
+        expect(result.warnings).toEqual([]);
+    });
+
+    it('supports template expressions inside quoted CSS values', async () => {
+        const code = dedent`
+            import {ChangeDetectionStrategy, Component, ViewEncapsulation} from '@angular/core';
+            import {TUI_VERSION} from '@taiga-ui/cdk/constants';
+            import {TUI_PLATFORM} from '@taiga-ui/cdk/tokens';
+            import {tuiInjectElement} from '@taiga-ui/cdk/utils/dom';
+            import {tuiWithStyles} from '@taiga-ui/cdk/utils/miscellaneous';
+            import {tuiChipOptionsProvider} from '@taiga-ui/kit/components/chip';
+
+            const OPTIONS = {
+                behavior: 'smooth',
+                block: 'nearest',
+                container: 'nearest',
+                inline: 'center',
+            } as const;
+
+            @Component({
+                template: '',
+                styles: \`
+                    [data-tui-version='\${TUI_VERSION}'] {
+                        @import './chip-group.styles.less';
+                    }
+                \`,
+                encapsulation: ViewEncapsulation.None,
+                changeDetection: ChangeDetectionStrategy.OnPush,
+                exportAs: \`tui-chip-group-\${TUI_VERSION}\`,
+            })
+            class Styles {}
+        `;
+
+        const valid = await lint(code, {'property-no-unknown': true});
+        const invalid = await lint(
+            code.replace("@import './chip-group.styles.less';", 'unknown-property: 1;'),
+            {'property-no-unknown': true},
+        );
+
+        expect(valid.warnings).toEqual([]);
+        expect(invalid.warnings).toEqual([
+            expect.objectContaining({
+                column: 13,
+                line: 19,
+                rule: 'property-no-unknown',
+                text: expect.stringContaining('unknown-property'),
+            }),
+        ]);
+    });
+
+    it('ignores unparseable template expressions and unrelated styles', async () => {
+        const code = dedent`
+            const metadata = {styles: \`.fake { unknown-property: 1; }\`};
+
+            @Component({
+                styles: \`:host { unknown-property: \${value}; }\`,
+            })
+            export class Test {}
+        `;
+
+        const result = await lint(code, {'property-no-unknown': true});
+
+        expect(result.warnings).toEqual([]);
+    });
+
+    it('continues linting after an unparseable dynamic style', async () => {
+        const code = dedent`
+            @Component({
+                styles: \`:host { color: \${value}; }\`,
+            })
+            export class First {}
+
+            @Component({
+                styles: \`.second { unknown-property: 1; }\`,
+            })
+            export class Second {}
+        `;
+
+        const result = await lint(code, {'property-no-unknown': true});
+
+        expect(result.warnings).toEqual([
+            expect.objectContaining({
+                line: 7,
+                text: expect.stringContaining('unknown-property'),
+            }),
+        ]);
+    });
+
+    it('preserves TypeScript when applying Stylelint fixes', async () => {
+        const code = dedent`
+            @Component({
+                selector: 'test',
+                styles: \`
+                    :host {
+                        color: #ffffff;
+                    }
+                \`,
+                template: '',
+            })
+            export class Test {}
+        `;
+
+        const result = await lint(code, {'color-hex-length': 'short'}, true);
+
+        expect(result.code).toBe(code.replace('#ffffff', '#fff'));
+    });
+
+    it('applies fixes across styles and preserves code between components', async () => {
+        const code = dedent`
+            @Component({
+                styles: [
+                    \`.first { color: #ffffff; }\`,
+                    '.second { background: #000000; }',
+                ],
+            })
+            export class First {}
+
+            const untouched = true;
+
+            @Component({
+                styles: \`.third { border-color: #aabbcc; }\`,
+            })
+            export class Second {}
+        `;
+
+        const result = await lint(code, {'color-hex-length': 'short'}, true);
+
+        expect(result.code).toBe(
+            code
+                .replace('#ffffff', '#fff')
+                .replace('#000000', '#000')
+                .replace('#aabbcc', '#abc'),
+        );
+    });
+
+    it('preserves a component without extractable styles during autofix', async () => {
+        const code = dedent`
+            @Component({
+                styles: externalStyles,
+                template: '<div />',
+            })
+            export class Test {}
+        `;
+
+        const result = await lint(code, {'color-hex-length': 'short'}, true);
+
+        expect(result.code).toBe(code);
+        expect(result.warnings).toEqual([]);
+    });
+});

--- a/projects/stylelint-config/tests/angular-inline-styles.spec.ts
+++ b/projects/stylelint-config/tests/angular-inline-styles.spec.ts
@@ -27,7 +27,90 @@ async function lint(
     });
 }
 
+function lintNative(
+    code: string,
+    rules?: Readonly<Record<string, unknown>>,
+    fix = false,
+): LintOutput {
+    // Native ESM avoids cross-realm PostCSS nodes and presets in Jest's VM.
+    return JSON.parse(
+        execFileSync(
+            process.execPath,
+            [
+                '--input-type=module',
+                '-e',
+                `
+                        import {createJiti} from 'jiti';
+                        import stylelint from 'stylelint';
+
+                        const jiti = createJiti(${JSON.stringify(__filename)});
+                        const config = await jiti.import(
+                            ${JSON.stringify(rules ? '../angular' : '../index')},
+                            {default: true},
+                        );
+                        const result = await stylelint.lint({
+                            code: ${JSON.stringify(code)},
+                            codeFilename: 'test.component.ts',
+                            config: {...config, ...${JSON.stringify(rules ? {rules} : {})}},
+                            fix: ${JSON.stringify(fix)},
+                        });
+
+                        process.stdout.write(JSON.stringify({
+                            code: result.code,
+                            warnings: result.results.flatMap(({warnings}) => warnings),
+                        }));
+                    `,
+            ],
+            {encoding: 'utf8'},
+        ),
+    );
+}
+
 describe('Angular inline styles', () => {
+    it('allows the same import in different components', () => {
+        const code = dedent`
+            @Component({
+                styles: \`[data-tui-version='\${TUI_VERSION}'] {
+                    @import './subheader.style.less';
+                }\`,
+            })
+            export class First {}
+
+            @Component({
+                styles: \`[data-tui-version='\${TUI_VERSION}'] {
+                    @import './subheader.style.less';
+                }\`,
+            })
+            export class Second {}
+        `;
+
+        const result = lintNative(code, {'no-duplicate-at-import-rules': true});
+
+        expect(result.warnings).toEqual([]);
+    });
+
+    it('still reports duplicate imports within one style block', () => {
+        const code = dedent`
+            @Component({
+                styles: \`
+                    @import './subheader.style.less';
+                    @import './subheader.style.less';
+                \`,
+            })
+            export class Test {}
+        `;
+
+        const result = lintNative(code, {'no-duplicate-at-import-rules': true});
+
+        expect(result.warnings).toEqual([
+            expect.objectContaining({
+                column: 9,
+                line: 4,
+                rule: 'no-duplicate-at-import-rules',
+            }),
+        ]);
+    });
+
     it.each([
         {lineBreak: '\n', styles: "':host { color: #ffffff; }'"},
         {lineBreak: '\r\n', styles: "':host { color: #ffffff; }'"},
@@ -42,35 +125,7 @@ import {Component} from '@angular/core';
 @Component({styles: ${styles}})
 export class Test {}`.replaceAll('\n', lineBreak);
 
-            // The full config loads ESM presets that Jest's CommonJS VM cannot import.
-            const result: LintOutput = JSON.parse(
-                execFileSync(
-                    process.execPath,
-                    [
-                        '--input-type=module',
-                        '-e',
-                        `
-                        import {createJiti} from 'jiti';
-                        import stylelint from 'stylelint';
-
-                        const jiti = createJiti(${JSON.stringify(__filename)});
-                        const config = await jiti.import('../index', {default: true});
-                        const result = await stylelint.lint({
-                            code: ${JSON.stringify(code)},
-                            codeFilename: 'test.component.ts',
-                            config,
-                            fix: true,
-                        });
-
-                        process.stdout.write(JSON.stringify({
-                            code: result.code,
-                            warnings: result.results.flatMap(({warnings}) => warnings),
-                        }));
-                    `,
-                    ],
-                    {encoding: 'utf8'},
-                ),
-            );
+            const result = lintNative(code, undefined, true);
 
             expect(result.code).toBe(code.replace('#ffffff', '#fff'));
             expect(result.warnings).toEqual([]);
@@ -365,8 +420,10 @@ export class Test {}`.replaceAll('\n', lineBreak);
         expect(result.code).toBe(code.replace('#ffffff', '#fff'));
     });
 
-    it('applies fixes across styles and preserves code between components', async () => {
-        const code = dedent`
+    it.each(['\n', '\r\n'])(
+        'preserves code between components during autofix (%j)',
+        (lineBreak) => {
+            const code = dedent`
             @Component({
                 styles: [
                     \`.first { color: #ffffff; }\`,
@@ -381,17 +438,18 @@ export class Test {}`.replaceAll('\n', lineBreak);
                 styles: \`.third { border-color: #aabbcc; }\`,
             })
             export class Second {}
-        `;
+        `.replaceAll('\n', lineBreak);
 
-        const result = await lint(code, {'color-hex-length': 'short'}, true);
+            const result = lintNative(code, {'color-hex-length': 'short'}, true);
 
-        expect(result.code).toBe(
-            code
-                .replace('#ffffff', '#fff')
-                .replace('#000000', '#000')
-                .replace('#aabbcc', '#abc'),
-        );
-    });
+            expect(result.code).toBe(
+                code
+                    .replace('#ffffff', '#fff')
+                    .replace('#000000', '#000')
+                    .replace('#aabbcc', '#abc'),
+            );
+        },
+    );
 
     it('preserves a component without extractable styles during autofix', async () => {
         const code = dedent`

--- a/projects/stylelint-config/tests/angular-inline-styles.spec.ts
+++ b/projects/stylelint-config/tests/angular-inline-styles.spec.ts
@@ -1,3 +1,5 @@
+import {execFileSync} from 'node:child_process';
+
 import {describe, expect, it} from '@jest/globals';
 
 import angularConfig from '../angular';
@@ -26,6 +28,55 @@ async function lint(
 }
 
 describe('Angular inline styles', () => {
+    it.each([
+        {lineBreak: '\n', styles: "':host { color: #ffffff; }'"},
+        {lineBreak: '\r\n', styles: "':host { color: #ffffff; }'"},
+        {lineBreak: '\n', styles: "''"},
+        {lineBreak: '\n', styles: 'externalStyles'},
+    ])(
+        'lints and fixes $styles with the full config ($lineBreak)',
+        ({lineBreak, styles}) => {
+            const code = `
+import {Component} from '@angular/core';
+
+@Component({styles: ${styles}})
+export class Test {}`.replaceAll('\n', lineBreak);
+
+            // The full config loads ESM presets that Jest's CommonJS VM cannot import.
+            const result: LintOutput = JSON.parse(
+                execFileSync(
+                    process.execPath,
+                    [
+                        '--input-type=module',
+                        '-e',
+                        `
+                        import {createJiti} from 'jiti';
+                        import stylelint from 'stylelint';
+
+                        const jiti = createJiti(${JSON.stringify(__filename)});
+                        const config = await jiti.import('../index', {default: true});
+                        const result = await stylelint.lint({
+                            code: ${JSON.stringify(code)},
+                            codeFilename: 'test.component.ts',
+                            config,
+                            fix: true,
+                        });
+
+                        process.stdout.write(JSON.stringify({
+                            code: result.code,
+                            warnings: result.results.flatMap(({warnings}) => warnings),
+                        }));
+                    `,
+                    ],
+                    {encoding: 'utf8'},
+                ),
+            );
+
+            expect(result.code).toBe(code.replace('#ffffff', '#fff'));
+            expect(result.warnings).toEqual([]);
+        },
+    );
+
     it('reports Stylelint warnings at the original TypeScript location', async () => {
         const code = dedent`
             import {Component} from '@angular/core';

--- a/projects/stylelint-config/tests/stylelint-test-utils.ts
+++ b/projects/stylelint-config/tests/stylelint-test-utils.ts
@@ -1,6 +1,8 @@
 import {createJiti} from 'jiti';
 
 interface StylelintWarning {
+    readonly column?: number;
+    readonly line?: number;
     readonly rule?: string;
     readonly text: string;
 }
@@ -20,12 +22,14 @@ interface StylelintApi {
 
 interface StylelintConfig {
     readonly customSyntax?: unknown;
+    readonly overrides?: readonly unknown[];
     readonly plugins?: readonly unknown[];
     readonly rules: Readonly<Record<string, unknown>>;
 }
 
 interface StylelintLintOptions {
     readonly code: string;
+    readonly codeFilename?: string;
     readonly config: StylelintConfig;
     readonly fix?: boolean;
 }
@@ -57,7 +61,9 @@ export async function lintWithStylelint(
     return {
         code,
         warnings:
-            result?.warnings.map(({rule, text}) => ({
+            result?.warnings.map(({column, line, rule, text}) => ({
+                column,
+                line,
                 rule,
                 text,
             })) ?? [],

--- a/projects/stylelint-config/tsconfig.json
+++ b/projects/stylelint-config/tsconfig.json
@@ -11,7 +11,8 @@
     "include": [
         "./*.ts",
         "configs/**/*.ts",
-        "rules/**/*.ts"
+        "rules/**/*.ts",
+        "syntaxes/**/*.ts"
     ],
     "exclude": ["**/*.spec.ts"]
 }


### PR DESCRIPTION
## Motivation

Stylelint currently checks standalone stylesheet files, but Angular inline component styles declared via `@Component({styles: ...})` are skipped because `.ts` files are not parsed as stylesheets.

## Changes

* add support for linting static Angular inline `styles`
* preserve original TypeScript line and column positions in Stylelint diagnostics
* support inline Less syntax
* support `styles` arrays
* preserve the surrounding TypeScript code when using `--fix`
* ignore dynamic template literals with substitutions
* include Angular inline style support in the default `@taiga-ui/stylelint-config`
* add integration tests for diagnostics and autofix

TypeScript files still need to be included in the Stylelint input, for example:

```bash
stylelint "**/*.{less,css,ts}"
```
